### PR TITLE
feat: add support for arm64 arch

### DIFF
--- a/download/downloadSpec.go
+++ b/download/downloadSpec.go
@@ -118,6 +118,8 @@ func detectArch() (string, error) {
 	switch goArch {
 	case "amd64":
 		return "x86_64", nil
+	case "arm64":
+		return "arm64", nil
 	default:
 		return "", &UnsupportedSystemError{msg: "architecture " + goArch + " not supported"}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestStart_All(t *testing.T) {
-	versions := []string{"4.4.8", "5.0.2"}
+	versions := []string{"6.0.4"}
 	testCtx := context.Background()
 
 	for _, version := range versions {


### PR DESCRIPTION
### What

Simple change that no longer returns an error when `arm64` goarch is detected

### How to review

Run the `make test` target